### PR TITLE
phase-7: AudioWorklet capture with anti-aliased downsampling

### DIFF
--- a/src/web/frontend/app/host/page.tsx
+++ b/src/web/frontend/app/host/page.tsx
@@ -27,7 +27,7 @@ export default function Host() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const frameIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
-  const audioProcessorRef = useRef<ScriptProcessorNode | null>(null);
+  const audioProcessorRef = useRef<AudioWorkletNode | null>(null);
 
   useEffect(() => {
     const initializeConnections = async () => {
@@ -354,7 +354,7 @@ export default function Host() {
     console.log("[DEBUG] Frame processing started");
   };
 
-  const startAudioProcessing = (stream: MediaStream) => {
+  const startAudioProcessing = async (stream: MediaStream) => {
     console.log("[DEBUG] Starting audio processing for redaction");
 
     const audioTrack = stream.getAudioTracks()[0];
@@ -374,67 +374,35 @@ export default function Host() {
         state: audioContext.state,
       });
 
-      // Create media stream source
+      // Load the AudioWorklet that downmixes to mono and anti-alias downsamples
+      // to 16 kHz on the audio render thread (replaces the deprecated
+      // ScriptProcessorNode + naïve every-3rd-sample decimation).
+      await audioContext.audioWorklet.addModule("/pcm-downsampler-worklet.js");
+
       const source = audioContext.createMediaStreamSource(stream);
+      const workletNode = new AudioWorkletNode(audioContext, "pcm-downsampler", {
+        numberOfInputs: 1,
+        numberOfOutputs: 1,
+        outputChannelCount: [1],
+        processorOptions: { targetSampleRate: 16000 },
+      });
+      audioProcessorRef.current = workletNode;
 
-      // Create script processor node (deprecated but still works)
-      const bufferSize = 4096; // Buffer size for processing
-      const processor = audioContext.createScriptProcessor(bufferSize, 2, 2); // Stereo
-      audioProcessorRef.current = processor;
-
-      // Process audio data
-      processor.onaudioprocess = (event) => {
-        const inputBuffer = event.inputBuffer;
-        const outputBuffer = event.outputBuffer;
-
-        // Get left and right channel data
-        const leftChannel = inputBuffer.getChannelData(0);
-        const rightChannel = inputBuffer.getChannelData(1);
-
-        // Mix stereo to mono by averaging channels
-        const monoData = new Float32Array(bufferSize);
-        for (let i = 0; i < bufferSize; i++) {
-          monoData[i] = (leftChannel[i] + rightChannel[i]) / 2;
-        }
-
-        // Downsample from 48kHz to 16kHz (3:1 ratio)
-        const downsampleRatio = 3;
-        const outputSamples = Math.floor(bufferSize / downsampleRatio);
-        const downsampledData = new Float32Array(outputSamples);
-
-        for (let i = 0; i < outputSamples; i++) {
-          // Simple downsampling - take every 3rd sample
-          downsampledData[i] = monoData[i * downsampleRatio];
-        }
-
-        // Convert float32 to int16 PCM data (16kHz mono)
-        const pcmData = new Int16Array(outputSamples);
-        for (let i = 0; i < outputSamples; i++) {
-          const sample = Math.max(-1, Math.min(1, downsampledData[i]));
-          pcmData[i] = sample * 0x7fff;
-        }
-
-        // Send PCM data to server for processing
+      // The worklet posts 16-bit PCM (16 kHz mono) as a transferred ArrayBuffer.
+      // Send it straight over the socket as a binary frame (see Phase 5 /
+      // docs/IMPROVEMENTS.md §2.1 for the matching server-side decode).
+      workletNode.port.onmessage = (event: MessageEvent) => {
         if (sfuSocketRef.current) {
-          sfuSocketRef.current.emit("audio-data", Array.from(pcmData));
-        }
-
-        // Copy input to output but muted to avoid feedback
-        for (
-          let channel = 0;
-          channel < outputBuffer.numberOfChannels;
-          channel++
-        ) {
-          const outputData = outputBuffer.getChannelData(channel);
-          outputData.fill(0); // Fill with silence to prevent feedback
+          sfuSocketRef.current.emit("audio-data", event.data as ArrayBuffer);
         }
       };
 
-      // Connect audio processing chain
-      source.connect(processor);
-      processor.connect(audioContext.destination); // Connect to ensure processing happens
+      // Connect source -> worklet -> destination. The worklet leaves its output
+      // silent, so connecting to destination keeps it scheduled without feedback.
+      source.connect(workletNode);
+      workletNode.connect(audioContext.destination);
 
-      console.log("[DEBUG] Audio processing pipeline connected");
+      console.log("[DEBUG] AudioWorklet processing pipeline connected");
     } catch (error) {
       console.error("[DEBUG] Audio processing setup error:", error);
     }

--- a/src/web/frontend/public/pcm-downsampler-worklet.js
+++ b/src/web/frontend/public/pcm-downsampler-worklet.js
@@ -1,0 +1,100 @@
+// AudioWorklet processor: downmix to mono, anti-aliased downsample to 16 kHz,
+// and emit 16-bit PCM to the main thread.
+//
+// Replaces the deprecated ScriptProcessorNode path. Runs on the audio render
+// thread (no main-thread jank). The old code took "every 3rd sample" with no
+// anti-alias filter, which folds everything above 8 kHz back into the band and
+// hurts Whisper transcription (and therefore PII recall). Here we low-pass with
+// a windowed-sinc FIR before decimating.
+//
+// processorOptions: { targetSampleRate?: number }  (default 16000)
+
+class PCMDownsampler extends AudioWorkletProcessor {
+  constructor(options) {
+    super();
+    const opts = (options && options.processorOptions) || {};
+    const target = opts.targetSampleRate || 16000;
+
+    // Integer decimation factor (e.g. 48000 -> 16000 = 3). `sampleRate` is a
+    // global available inside AudioWorkletGlobalScope.
+    this.ratio = Math.max(1, Math.round(sampleRate / target));
+
+    // Windowed-sinc low-pass FIR, cutoff at the post-decimation Nyquist.
+    this.taps = PCMDownsampler.buildLowpass(31, 0.5 / this.ratio);
+
+    // Ring buffer of recent mono input for the FIR convolution.
+    this.history = new Float32Array(this.taps.length);
+    this.histPos = 0;
+    this.phase = 0; // counts input samples toward the next decimated output
+
+    // Batch output to ~100 ms before posting, to keep message rate low.
+    this.flushSize = Math.max(1, Math.round(target * 0.1));
+    this.outBuf = new Float32Array(this.flushSize);
+    this.outLen = 0;
+  }
+
+  // Symmetric (linear-phase) low-pass via sinc * Hamming window, DC-normalized.
+  static buildLowpass(numTaps, fc) {
+    const taps = new Float32Array(numTaps);
+    const mid = (numTaps - 1) / 2;
+    let sum = 0;
+    for (let i = 0; i < numTaps; i++) {
+      const n = i - mid;
+      const sinc = n === 0 ? 2 * Math.PI * fc : Math.sin(2 * Math.PI * fc * n) / n;
+      const window = 0.54 - 0.46 * Math.cos((2 * Math.PI * i) / (numTaps - 1));
+      taps[i] = sinc * window;
+      sum += taps[i];
+    }
+    for (let i = 0; i < numTaps; i++) taps[i] /= sum;
+    return taps;
+  }
+
+  flush() {
+    if (this.outLen === 0) return;
+    const pcm = new Int16Array(this.outLen);
+    for (let i = 0; i < this.outLen; i++) {
+      const s = Math.max(-1, Math.min(1, this.outBuf[i]));
+      pcm[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+    }
+    // Transfer the buffer to avoid a copy.
+    this.port.postMessage(pcm.buffer, [pcm.buffer]);
+    this.outLen = 0;
+  }
+
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || input.length === 0) return true; // keep the node alive
+
+    const channels = input.length;
+    const frames = input[0].length;
+
+    for (let i = 0; i < frames; i++) {
+      // Downmix to mono.
+      let mono = 0;
+      for (let c = 0; c < channels; c++) mono += input[c][i];
+      mono /= channels;
+
+      // Feed the FIR history ring.
+      this.history[this.histPos] = mono;
+      this.histPos = (this.histPos + 1) % this.history.length;
+
+      // Emit one filtered sample every `ratio` input samples.
+      if (++this.phase >= this.ratio) {
+        this.phase = 0;
+        let acc = 0;
+        let idx = this.histPos - 1;
+        for (let k = 0; k < this.taps.length; k++) {
+          if (idx < 0) idx += this.history.length;
+          acc += this.taps[k] * this.history[idx];
+          idx--;
+        }
+        this.outBuf[this.outLen++] = acc;
+        if (this.outLen >= this.flushSize) this.flush();
+      }
+    }
+
+    return true; // outputs left silent — no feedback
+  }
+}
+
+registerProcessor("pcm-downsampler", PCMDownsampler);


### PR DESCRIPTION
## Phase 7 of the `docs/IMPROVEMENTS.md` remediation roadmap

🟠 **AudioWorklet capture + anti-aliased resampling** (§2.2, §2.3).

### Changes
- **New `public/pcm-downsampler-worklet.js`** — an `AudioWorkletProcessor` that runs on the audio render thread (no main-thread jank, unlike the deprecated `ScriptProcessorNode`). It downmixes to mono and downsamples 48 kHz → 16 kHz with a **windowed-sinc low-pass FIR applied before decimation**, instead of the old "take every 3rd sample" approach that aliased everything above 8 kHz back into the band (degrading Whisper transcription and therefore PII recall). Output is batched to ~100 ms and posted as transferred 16-bit PCM.
- **`host/page.tsx`** — loads the worklet via `audioWorklet.addModule`, wires `source → AudioWorkletNode → destination` (output left silent, no feedback), and emits the PCM `ArrayBuffer` as a binary socket frame.

### Verification
- `node --check` passes on the worklet; `createScriptProcessor` is gone from the host path.
- ⚠️ **Unverified at runtime** — needs a browser to confirm audio actually flows through the worklet (no headless way to test here).

### Merge ordering
The binary `audio-data` emit pairs with the **Phase 5** server-side binary decode (#6). **Land this together with or after #6** — against a server that still expects the JSON number array, the binary frame would be misparsed. (The two PRs both touch the host emit line, so expect a trivial conflict resolved in favour of this version.)

### Note
`lib/audio-redaction-client.ts` also uses `createScriptProcessor` but is **imported nowhere** (dead code, out of the runtime path), so it was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyV6x9SovhKVBRrU5mLL1N)_